### PR TITLE
修改group设置方式，增加返回数据的字符编码设置

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 /target/
 
 .settings/*
+*.iml
+*.idea

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,11 @@
 			<artifactId>gson</artifactId>
 			<version>2.8.2</version>
 		</dependency>
+		<dependency>
+			<groupId>com.alibaba</groupId>
+			<artifactId>fastjson</artifactId>
+			<version>1.2.35</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/src/main/java/io/github/ningyu/jmeter/plugin/dubbo/gui/DubboSampleGui.java
+++ b/src/main/java/io/github/ningyu/jmeter/plugin/dubbo/gui/DubboSampleGui.java
@@ -70,6 +70,7 @@ public class DubboSampleGui extends AbstractSamplerGui {
     private JTextField methodText;
     private JTextField groupText;
     private JTextField connectionsText;
+    private JTextField responseEncodingText;
     private JComboBox<String> loadbalanceText;
     private JComboBox<String> asyncText;
     private DefaultTableModel model;
@@ -175,6 +176,13 @@ public class DubboSampleGui extends AbstractSamplerGui {
         connectionsLable.setLabelFor(connectionsText);
         h.add(connectionsLable);
         h.add(connectionsText);
+
+        JLabel respEncodingLabel = new JLabel("RespEncoding:", SwingConstants.RIGHT);
+        responseEncodingText = new JTextField(textColumns);
+        responseEncodingText.setText(DubboSample.DEFAULT_ENCODING);
+        respEncodingLabel.setLabelFor(responseEncodingText);
+        h.add(respEncodingLabel);
+        h.add(responseEncodingText);
         consumerSettings.add(h);
         
         JPanel hp1 = new HorizontalPanel();
@@ -280,6 +288,7 @@ public class DubboSampleGui extends AbstractSamplerGui {
         loadbalanceText.setSelectedItem(sample.getLoadbalance());
         asyncText.setSelectedItem(sample.getAsync());
         clusterText.setText(sample.getCluster());
+        responseEncodingText.setText(sample.getEncoding());
         interfaceText.setText(sample.getInterface());
         methodText.setText(sample.getMethod());
         Vector<String> columnNames = new Vector<String>();
@@ -326,6 +335,7 @@ public class DubboSampleGui extends AbstractSamplerGui {
         sample.setRetries(retriesText.getText());
         sample.setGroup(groupText.getText());
         sample.setConnections(connectionsText.getText());
+        sample.setEncoding(responseEncodingText.getText());
         sample.setLoadbalance(loadbalanceText.getSelectedItem().toString());
         sample.setAsync(asyncText.getSelectedItem().toString());
         sample.setCluster(clusterText.getText());

--- a/src/main/java/io/github/ningyu/jmeter/plugin/dubbo/sample/DubboSample.java
+++ b/src/main/java/io/github/ningyu/jmeter/plugin/dubbo/sample/DubboSample.java
@@ -67,11 +67,11 @@ public class DubboSample extends AbstractSampler {
     public static String FIELD_DUBBO_METHOD = "FIELD_DUBBO_METHOD";
     public static String FIELD_DUBBO_METHOD_ARGS = "FIELD_DUBBO_METHOD_ARGS";
     public static String FIELD_DUBBO_METHOD_ARGS_SIZE = "FIELD_DUBBO_METHOD_ARGS_SIZE";
-    public static String DEFAULT_TIMEOUT = "1000";
+    public static String DEFAULT_TIMEOUT = "3000";
     public static String DEFAULT_VERSION = "1.0.0";
     public static String DEFAULT_RETRIES = "0";
     public static String DEFAULT_CLUSTER = "failfast";
-    public static String DEFAULT_CONNECTIONS = "100";
+    public static String DEFAULT_CONNECTIONS = "1";
 
     /**
      * get Registry Protocol
@@ -364,11 +364,13 @@ public class DubboSample extends AbstractSampler {
         RegistryConfig registry = null;
         
         String protocol = getRegistryProtocol();
+        String group = getGroup();
 		switch (protocol) {
 		case Constants.REGISTRY_ZOOKEEPER:
 			registry = new RegistryConfig();
 			registry.setProtocol(Constants.REGISTRY_ZOOKEEPER);
 			registry.setAddress(getAddress());
+			registry.setGroup(StringUtils.isBlank(group) ? null : group);
 			reference.setRegistry(registry);
 			reference.setProtocol(getRpcProtocol().replaceAll("://", ""));
 			break;
@@ -376,6 +378,7 @@ public class DubboSample extends AbstractSampler {
 			registry = new RegistryConfig();
 			registry.setProtocol(Constants.REGISTRY_MULTICAST);
 			registry.setAddress(getAddress());
+            registry.setGroup(StringUtils.isBlank(group) ? null : group);
 			reference.setRegistry(registry);
 			reference.setProtocol(getRpcProtocol().replaceAll("://", ""));
 			break;
@@ -383,12 +386,14 @@ public class DubboSample extends AbstractSampler {
 			registry = new RegistryConfig();
 			registry.setProtocol(Constants.REGISTRY_REDIS);
 			registry.setAddress(getAddress());
+            registry.setGroup(StringUtils.isBlank(group) ? null : group);
 			reference.setRegistry(registry);
 			reference.setProtocol(getRpcProtocol().replaceAll("://", ""));
 			break;
 		case Constants.REGISTRY_SIMPLE:
 			registry = new RegistryConfig();
 			registry.setAddress(getAddress());
+            registry.setGroup(StringUtils.isBlank(group) ? null : group);
 			reference.setRegistry(registry);
 			reference.setProtocol(getRpcProtocol().replaceAll("://", ""));
 			break;
@@ -405,8 +410,6 @@ public class DubboSample extends AbstractSampler {
             reference.setCluster(getCluster());
             reference.setVersion(getVersion());
             reference.setTimeout(Integer.valueOf(getTimeout()));
-            String group = getGroup();
-            reference.setGroup(StringUtils.isBlank(group) ? null : group);
             reference.setConnections(Integer.valueOf(getConnections()));
             reference.setLoadbalance(getLoadbalance());
             reference.setAsync(Constants.ASYNC.equals(getAsync()) ? true : false);

--- a/src/main/java/io/github/ningyu/jmeter/plugin/dubbo/sample/DubboSample.java
+++ b/src/main/java/io/github/ningyu/jmeter/plugin/dubbo/sample/DubboSample.java
@@ -72,7 +72,7 @@ public class DubboSample extends AbstractSampler {
     public static String DEFAULT_TIMEOUT = "3000";
     public static String DEFAULT_VERSION = "1.0.0";
     public static String DEFAULT_RETRIES = "0";
-    public static String DEFAULT_CLUSTER = "failfast";
+    public static String DEFAULT_CLUSTER = "failover";
     public static String DEFAULT_CONNECTIONS = "1";
     public static String DEFAULT_ENCODING = "UTF-8";
 

--- a/src/main/java/io/github/ningyu/jmeter/plugin/dubbo/sample/DubboSample.java
+++ b/src/main/java/io/github/ningyu/jmeter/plugin/dubbo/sample/DubboSample.java
@@ -16,6 +16,7 @@
  */
 package io.github.ningyu.jmeter.plugin.dubbo.sample;
 
+import com.alibaba.fastjson.JSON;
 import io.github.ningyu.jmeter.plugin.util.ClassUtils;
 import io.github.ningyu.jmeter.plugin.util.Constants;
 import io.github.ningyu.jmeter.plugin.util.JsonUtils;
@@ -60,6 +61,7 @@ public class DubboSample extends AbstractSampler {
     public static String FIELD_DUBBO_RETRIES = "FIELD_DUBBO_RETRIES";
     public static String FIELD_DUBBO_CLUSTER = "FIELD_DUBBO_CLUSTER";
     public static String FIELD_DUBBO_GROUP = "FIELD_DUBBO_GROUP";
+    public static String FIELD_DUBBO_RESP_ENCODING = "FIELD_DUBBO_RESP_ENCODING";
     public static String FIELD_DUBBO_CONNECTIONS = "FIELD_DUBBO_CONNECTIONS";
     public static String FIELD_DUBBO_LOADBALANCE = "FIELD_DUBBO_LOADBALANCE";
     public static String FIELD_DUBBO_ASYNC = "FIELD_DUBBO_ASYNC";
@@ -72,6 +74,8 @@ public class DubboSample extends AbstractSampler {
     public static String DEFAULT_RETRIES = "0";
     public static String DEFAULT_CLUSTER = "failfast";
     public static String DEFAULT_CONNECTIONS = "1";
+    public static String DEFAULT_ENCODING = "UTF-8";
+
 
     /**
      * get Registry Protocol
@@ -216,7 +220,15 @@ public class DubboSample extends AbstractSampler {
     public void setConnections(String connections) {
     	this.setProperty(new StringProperty(FIELD_DUBBO_CONNECTIONS, connections));
     }
-    
+
+    public void setEncoding(String encoding) {
+        this.setProperty(new StringProperty(FIELD_DUBBO_RESP_ENCODING, encoding));
+    }
+
+    public String getEncoding() {
+        return this.getPropertyAsString(FIELD_DUBBO_RESP_ENCODING, DEFAULT_ENCODING);
+    }
+
     /**
      * get loadbalance
      * @return the loadbalance
@@ -321,7 +333,8 @@ public class DubboSample extends AbstractSampler {
         //构造请求数据
         res.setSamplerData(getSampleData());
         //调用dubbo
-        res.setResponseData(JsonUtils.toJson(callDubbo(res)));
+        res.setResponseData(JSON.toJSONString(callDubbo(res)),getEncoding());
+//        res.setResponseData(JsonUtils.toJson(callDubbo(res)));
         //构造响应数据
         res.setDataType(SampleResult.TEXT);
         res.setResponseCodeOK();
@@ -362,7 +375,7 @@ public class DubboSample extends AbstractSampler {
         // 引用远程服务
         reference.setApplication(application);
         RegistryConfig registry = null;
-        
+
         String protocol = getRegistryProtocol();
         String group = getGroup();
 		switch (protocol) {


### PR DESCRIPTION
修改group设置方式，例如 group= dubbo/TEST 时使用reference.setGroup()会校验失败， 换成registory.setGroup可以正常通过。
增加返回字符encoding方便在结果树中查看中文内容